### PR TITLE
Fix typos and remove broken links

### DIFF
--- a/internal/messages/resources.go
+++ b/internal/messages/resources.go
@@ -10,17 +10,16 @@ const Resources = `
 	- <a href="https://go.dev/blog/">The Go blog</a>
 	- <a href="https://golangweekly.com/issues/latest">Golang weekly</a>
 	- <a href="https://yourbasic.org/golang/">Go go-to guide</a>
-	- <a href="https://golang50shad.es/">50 Go common gotchas</a>
 	- <a href="https://100go.co/">100 Go mistakes</a>
 	- <a href="https://roadmap.sh/golang">Go roadmap</a>
 
 <i>Українською 🇺🇦:</i>
 	- <a href="https://go-tour-ua-translation.lm.r.appspot.com/welcome/1">Go tour (переклад)</a>
 	- <a href="https://butuzov.github.io/gobyexample/">Go by example (переклад)</a>
-	- <a href="https://www.youtube.com/playlist?list=PL7PnqERoHp6jLHoYrenz9cwJojFlNyENr">Intellias Go coures</a>
+	- <a href="https://www.youtube.com/playlist?list=PL7PnqERoHp6jLHoYrenz9cwJojFlNyENr">Intellias Go courses</a>
 	- <a href="https://www.youtube.com/@gou.ukraine">Gou Ukraine</a>
 	- <a href="https://www.youtube.com/@bluegophercult">Культ синього ховраха</a>
-	- <a href="https://www.youtube.com/@GolangUA">GolangUA Youtube</a>
+	- <a href="https://www.youtube.com/@GolangUA">GolangUA YouTube</a>
 	- <a href="https://github.com/golangua">GolangUA GitHub</a>
 
 Більше інформації шукай <a href="https://bit.ly/3XCIKT4">тут</a>.


### PR DESCRIPTION
Fix these suggestions:

"Помилка в слові «coures». Має бути «courses».

Сайт https://golang50shad.es/ недоступний.

“Youtube” -> “YouTube”"