### PR TITLE
chore: enable mistakenly disabled sloglint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,6 @@ linters:
     - noctx
     - nonamedreturns
     - paralleltest
-    - sloglint
     - tagliatelle
     - testableexamples
     - testpackage


### PR DESCRIPTION
The [`sloglint`](https://golangci-lint.run/docs/linters/configuration/#sloglint) linter checks `log/slog`, so it's useful for this project.