### PR TITLE
chore: remove unused nolint comment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,6 +53,8 @@ linters:
       locale: US
     nestif:
       min-complexity: 7
+    nolintlint:
+      require-specific: true
     revive:
       enable-all-rules: true
       rules:

--- a/internal/handler/callback/callbackdata/parser.go
+++ b/internal/handler/callback/callbackdata/parser.go
@@ -22,7 +22,7 @@ var (
 
 func Parse(data string) (*Payload, error) {
 	splits := strings.Split(data, "_")
-	if len(splits) != 3 { //nolint:gomnd,mnd
+	if len(splits) != 3 {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidCallbackData, splits)
 	}
 


### PR DESCRIPTION
`mnd` is disabled, `gomnd` is removed in v2