### PR TITLE
chore: improve linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ jobs:
           go-version-file: "go.mod"
           check-latest: true
 
-      - name: Gofmt check
-        run: diff -u <(echo -n) <(gofmt -d .)
+      - name: Save GOLANGCI_LINT_VERSION to output from Taskfile.yaml
+        id: golangci-lint-version
+        run: echo "GOLANGCI_LINT_VERSION=$(grep 'GOLANGCI_LINT_VERSION:' Taskfile.yaml | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Golangci Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.3
+          version: ${{ steps.golangci-lint-version.outputs.GOLANGCI_LINT_VERSION }}
+          args: --verbose
 
   test:
     name: Tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -114,3 +114,5 @@ formatters:
         - standard
         - default
         - prefix(github.com/GolangUA/telegram-butler)
+    gofumpt:
+      extra-rules: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,20 +6,16 @@ linters:
     - contextcheck
     - cyclop
     - depguard
-    - dupl
     - err113
     - exhaustruct
     - gochecknoglobals
     - gochecknoinits
-    - godot
-    - godox
+    - gomodguard # deprecated
     - interfacebloat
     - ireturn
     - maintidx
     - mnd
-    - nakedret
     - nlreturn
-    - noctx
     - nonamedreturns
     - paralleltest
     - tagliatelle
@@ -38,6 +34,8 @@ linters:
       statements: 60
     gocognit:
       min-complexity: 40
+    goconst:
+      ignore-tests: true
     gocyclo:
       min-complexity: 40
     govet:
@@ -57,55 +55,30 @@ linters:
     revive:
       enable-all-rules: true
       rules:
-        - name: add-constant
-          disabled: true
-        - name: argument-limit
-          disabled: true
-        - name: banned-characters
-          disabled: true
-        - name: bare-return
-          disabled: true
-        - name: blank-imports
+        - name: add-constant # duplicate of goconst
           disabled: true
         - name: cognitive-complexity
           disabled: true
-        - name: comment-spacings
-          arguments:
-            - nolint
-          severity: warning
-          disabled: false
         - name: cyclomatic
           disabled: true
         - name: confusing-naming
           disabled: true
         - name: exported
           disabled: true
-        - name: import-alias-naming
-          disabled: true
-        - name: file-header
-          disabled: true
         - name: function-result-limit
           arguments:
             - 4
-          severity: warning
-          disabled: false
-        - name: function-length
+        - name: function-length # duplicate of funlen
           disabled: true
         - name: flag-parameter
           disabled: true
         - name: import-shadowing
           disabled: true
         - name: line-length-limit
-          disabled: true
+          disabled: true # duplicate of lll
         - name: max-public-structs
           disabled: true
-        - name: modifies-value-receiver
-          disabled: true
         - name: package-comments
-          disabled: true
-        - name: unused-receiver
-          disabled: true
-        - name: var-naming
           disabled: true
     sloglint:
       no-mixed-args: true
@@ -120,19 +93,12 @@ linters:
         - all
         - -ST1000
         - -ST1003
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-temp-dir: true
   exclusions:
-    generated: lax
-    rules:
-      - linters:
-          - lll
-        source: '^//go:generate '
-      - linters:
-          - funlen
-        path: _test\.go$
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    warn-unused: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -148,9 +114,3 @@ formatters:
         - standard
         - default
         - prefix(github.com/GolangUA/telegram-butler)
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,6 +2,9 @@ version: 3
 
 silent: true
 
+vars:
+  GOLANGCI_LINT_VERSION: v2.12.2
+
 tasks:
   default:
     desc: "Show available tasks"
@@ -29,19 +32,11 @@ tasks:
 
   format:
     desc: "Run formatters"
-    deps: [ install:gofumpt, install:gci ]
+    deps: [ install:lint ]
     aliases: [ fmt ]
     cmds:
       - echo "Running formatters..."
-      - go mod tidy
-      - gofumpt -l -w .
-      - |
-        gci write \
-        --skip-generated \
-        --section standard \
-        --section default \
-        --section "prefix(github.com/GolangUA/telegram-butler)" \
-        $(go list -f "{{`{{.Dir}}`}}" ./...)
+      - golangci-lint fmt
     sources:
       - ./**/*.go
       - go.mod
@@ -105,34 +100,10 @@ tasks:
     desc: "Install all tools"
     deps:
       - install:lint
-      - install:gofumpt
-      - install:gci
-      - install:mock
 
   install:lint:
     desc: "Install golangci-lint"
     cmds:
-      - curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
+      - curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin {{.GOLANGCI_LINT_VERSION}}
     status:
       - command -v golangci-lint
-
-  install:gofumpt:
-    desc: "Install gofumpt"
-    cmds:
-      - go install mvdan.cc/gofumpt@latest
-    status:
-      - command -v gofumpt
-
-  install:gci:
-    desc: "Install gci"
-    cmds:
-      - go install github.com/daixiang0/gci@latest
-    status:
-      - command -v gci
-
-  install:mock:
-    desc: "Install mockgen"
-    cmds:
-      - go install go.uber.org/mock/mockgen@latest
-    status:
-      - command -v mockgen

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -12,9 +12,8 @@ tasks:
       - task --list-all
 
   pre-commit:
-    desc: "Run generators, formatters, linters, tests"
+    desc: "Run formatters, linters, tests"
     cmds:
-      - task: generate
       - task: format
       - task: lint
       - task: test
@@ -84,17 +83,6 @@ tasks:
     desc: "Run tests with a race flag"
     cmds:
       - go test -race -count=8 -failfast ./...
-
-  generate:
-    desc: "Generate (used for mock generation)"
-    deps: [ install:mock ]
-    cmds:
-      - echo "Running generators..."
-      - go generate ./...
-    sources:
-      - ./**/*.go
-      - go.mod
-      - go.sum
 
   install:
     desc: "Install all tools"

--- a/cmd/telegram-butler/setup.go
+++ b/cmd/telegram-butler/setup.go
@@ -105,5 +105,5 @@ func setup(ctx context.Context, log *slog.Logger) (run func() error, stop func()
 		return nil
 	}
 
-	return
+	return run, stop, nil
 }

--- a/cmd/telegram-butler/setup.go
+++ b/cmd/telegram-butler/setup.go
@@ -18,7 +18,7 @@ import (
 	"github.com/GolangUA/telegram-butler/internal/module/telegram"
 )
 
-func setup(ctx context.Context, log *slog.Logger) (run func() error, stop func() error, err error) {
+func setup(ctx context.Context, log *slog.Logger) (run, stop func() error, err error) {
 	log.Info("Setting up the Bot")
 
 	botCfg := config.Bot()

--- a/internal/handler/callback/handler.go
+++ b/internal/handler/callback/handler.go
@@ -23,7 +23,7 @@ func Register(bh *th.BotHandler) {
 
 type handler struct{}
 
-func (h *handler) callbackQuery(ctx *th.Context, query telego.CallbackQuery) error {
+func (*handler) callbackQuery(ctx *th.Context, query telego.CallbackQuery) error {
 	log := logger.FromContext(ctx)
 
 	log = log.With(slog.Group("user",

--- a/internal/handler/message/handler.go
+++ b/internal/handler/message/handler.go
@@ -22,7 +22,7 @@ func Register(bh *th.BotHandler) {
 
 type handler struct{}
 
-func (h *handler) rules(ctx *th.Context, message telego.Message) error {
+func (*handler) rules(ctx *th.Context, message telego.Message) error {
 	log := logger.FromContext(ctx)
 
 	log = log.With(slog.Group("user",
@@ -48,7 +48,7 @@ func (h *handler) rules(ctx *th.Context, message telego.Message) error {
 	return nil
 }
 
-func (h *handler) usefulInfo(ctx *th.Context, message telego.Message) error {
+func (*handler) usefulInfo(ctx *th.Context, message telego.Message) error {
 	log := logger.FromContext(ctx)
 
 	log = log.With(slog.Group("user",
@@ -74,7 +74,7 @@ func (h *handler) usefulInfo(ctx *th.Context, message telego.Message) error {
 	return nil
 }
 
-func (h *handler) help(ctx *th.Context, message telego.Message) error {
+func (*handler) help(ctx *th.Context, message telego.Message) error {
 	log := logger.FromContext(ctx)
 
 	log = log.With(slog.Group("user",

--- a/internal/handler/mute/handler.go
+++ b/internal/handler/mute/handler.go
@@ -119,7 +119,7 @@ var adminStatuses = []string{
 	telego.MemberStatusAdministrator,
 }
 
-func (h *handler) isAdmin(ctx *th.Context, chatID telego.ChatID, userID int64) (bool, error) {
+func (*handler) isAdmin(ctx *th.Context, chatID telego.ChatID, userID int64) (bool, error) {
 	member, err := ctx.Bot().GetChatMember(ctx, &telego.GetChatMemberParams{
 		ChatID: chatID,
 		UserID: userID,
@@ -131,7 +131,7 @@ func (h *handler) isAdmin(ctx *th.Context, chatID telego.ChatID, userID int64) (
 	return slices.Contains(adminStatuses, member.MemberStatus()), nil
 }
 
-func (h *handler) restrictUser(
+func (*handler) restrictUser(
 	ctx *th.Context, chatID telego.ChatID, userID int64, duration time.Duration,
 ) error {
 	return ctx.Bot().RestrictChatMember(ctx, &telego.RestrictChatMemberParams{
@@ -179,7 +179,7 @@ func (h *handler) replyWithError(ctx *th.Context, log *slog.Logger, message tele
 	}
 }
 
-func (h *handler) sendAndCleanup(ctx *th.Context, message telego.Message, errText string) error {
+func (*handler) sendAndCleanup(ctx *th.Context, message telego.Message, errText string) error {
 	reply, err := ctx.Bot().SendMessage(ctx, &telego.SendMessageParams{
 		ChatID:          message.Chat.ChatID(),
 		MessageThreadID: message.MessageThreadID,

--- a/internal/module/logger/format.go
+++ b/internal/module/logger/format.go
@@ -8,7 +8,7 @@ import (
 
 const LevelTrace = slog.Level(-8)
 
-func Setup(logLevel string, logFormat string, addSource bool) *slog.Logger {
+func Setup(logLevel, logFormat string, addSource bool) *slog.Logger {
 	var level slog.Level
 	if strings.EqualFold(logLevel, "trace") {
 		level = LevelTrace

--- a/internal/module/telegram/webhook.go
+++ b/internal/module/telegram/webhook.go
@@ -43,7 +43,7 @@ type WebhookConfig struct {
 	URL   url.URL
 }
 
-// LogValue satisfies the slog.LogValuer interface for WebhookConfig
+// LogValue satisfies the slog.LogValuer interface for WebhookConfig.
 func (w WebhookConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("bot_token", "[REDACTED]"),


### PR DESCRIPTION
This PR introduces several improvements and refactorings to the linting setup:

1. Upgrade golangci-lint to the latest v2.12.2
2. Enable more linters: `dupl`, `godox`, `godot`, `nakedret`
3. Enable `revive` rules
4. Fix config warnings after enabling `exclusions.warn-unused: true`
5. Replace `gofumpt` + `gci` with `golangci-lint fmt` (that internally uses `gofumpt` and `gci`)
6. Remove unused mockgen and `task generate`
7. Sync golangci-lint versions between Taskfile.yml and ci.yml. Now we need to update only `GOLANGCI_LINT_VERSION` in Taskfile.yml
